### PR TITLE
Fix code scanning alert no. 14: Useless regular-expression character escape

### DIFF
--- a/assets/plugins/bootstrap-wysihtml5/bootstrap3-wysihtml5.all.js
+++ b/assets/plugins/bootstrap-wysihtml5/bootstrap3-wysihtml5.all.js
@@ -4207,7 +4207,7 @@ wysihtml5.browser = (function() {
     if (navigator.appName == 'Microsoft Internet Explorer') {
       re = new RegExp("MSIE ([0-9]{1,}[\.0-9]{0,})");
     } else if (navigator.appName == 'Netscape') {
-      re = new RegExp("Trident/.*rv:([0-9]{1,}[\.0-9]{0,})");
+      re = new RegExp("Trident/.*rv:([0-9]{1,}[.0-9]{0,})");
     }
 
     if (re && re.exec(navigator.userAgent) != null) {


### PR DESCRIPTION
Fixes [https://github.com/ronknight/InventorySystem/security/code-scanning/14](https://github.com/ronknight/InventorySystem/security/code-scanning/14)

To fix the problem, we need to remove the unnecessary backslash from the regular expression. This will ensure that the regular expression is clear and does not contain any superfluous escape sequences. Specifically, we will change `\.` to `.` in the regular expression on line 4210.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
