### PR TITLE
Fix code scanning alert no. 13: Useless regular-expression character escape

### DIFF
--- a/assets/plugins/bootstrap-wysihtml5/bootstrap3-wysihtml5.all.js
+++ b/assets/plugins/bootstrap-wysihtml5/bootstrap3-wysihtml5.all.js
@@ -4205,7 +4205,7 @@ wysihtml5.browser = (function() {
         re;
 
     if (navigator.appName == 'Microsoft Internet Explorer') {
-      re = new RegExp("MSIE ([0-9]{1,}[\.0-9]{0,})");
+      re = new RegExp("MSIE ([0-9]{1,}[.0-9]{0,})");
     } else if (navigator.appName == 'Netscape') {
       re = new RegExp("Trident/.*rv:([0-9]{1,}[.0-9]{0,})");
     }


### PR DESCRIPTION
Fixes [https://github.com/ronknight/InventorySystem/security/code-scanning/13](https://github.com/ronknight/InventorySystem/security/code-scanning/13)

To fix the problem, we need to remove the unnecessary escape sequence `\.` from the regular expression on line 4208. The dot character should be used directly without the backslash. This change will not affect the functionality of the code but will improve its readability.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
