### PR TITLE
Fix code scanning alert no. 12: Useless regular-expression character escape

### DIFF
--- a/assets/plugins/input-mask/jquery.inputmask.numeric.extensions.js
+++ b/assets/plugins/input-mask/jquery.inputmask.numeric.extensions.js
@@ -167,7 +167,7 @@ Optional extensions on the jquery.inputmask base
             regex: {
                 number: function (opts) {
                     var escapedGroupSeparator = $.inputmask.escapeRegex.call(this, opts.groupSeparator);
-                    var signedExpression = opts.allowPlus || opts.allowMinus ? "[" + (opts.allowPlus ? "\+" : "") + (opts.allowMinus ? "-" : "") + "]?" : "";
+                    var signedExpression = opts.allowPlus || opts.allowMinus ? "[" + (opts.allowPlus ? "+" : "") + (opts.allowMinus ? "-" : "") + "]?" : "";
                     return new RegExp("^" + signedExpression + "(\\d+|\\d{1," + opts.groupSize + "}((" + escapedGroupSeparator + "\\d{" + opts.groupSize + "})?)+)$");
                 }
             },


### PR DESCRIPTION
Fixes [https://github.com/ronknight/InventorySystem/security/code-scanning/12](https://github.com/ronknight/InventorySystem/security/code-scanning/12)

To fix the problem, we need to remove the unnecessary escape sequence `\+` and replace it with `+`. This change will not affect the functionality of the code but will make it cleaner and easier to read.

- Locate the line with the unnecessary escape sequence in the file `assets/plugins/input-mask/jquery.inputmask.numeric.extensions.js`.
- Replace `\+` with `+` in the regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
