### PR TITLE
Fix code scanning alert no. 10: Useless regular-expression character escape

### DIFF
--- a/assets/plugins/input-mask/jquery.inputmask.numeric.extensions.js
+++ b/assets/plugins/input-mask/jquery.inputmask.numeric.extensions.js
@@ -61,7 +61,7 @@ Optional extensions on the jquery.inputmask base
                     bufVal = bufVal.replace(new RegExp(escapedGroupSeparator, "g"), '');
                     var radixSplit = bufVal.split(opts.radixPoint);
                     bufVal = radixSplit[0];
-                    var reg = new RegExp('([-\+]?[\\d\?]+)([\\d\?]{' + opts.groupSize + '})');
+                    var reg = new RegExp('([-\+]?[\\d?]+)([\\d?]{' + opts.groupSize + '})');
                     while (reg.test(bufVal)) {
                         bufVal = bufVal.replace(reg, '$1' + opts.groupSeparator + '$2');
                         bufVal = bufVal.replace(opts.groupSeparator + opts.groupSeparator, opts.groupSeparator);


### PR DESCRIPTION
Fixes [https://github.com/ronknight/InventorySystem/security/code-scanning/10](https://github.com/ronknight/InventorySystem/security/code-scanning/10)

To fix the problem, we need to remove the unnecessary escape sequence `\?` from the regular expression on line 64. This will make the code cleaner and easier to understand without changing its functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
